### PR TITLE
fix duplicate device name

### DIFF
--- a/services/Device.js
+++ b/services/Device.js
@@ -82,7 +82,8 @@ function rebootDevice(deviceId, cb) {
    var params = {
      device_id: options.deviceId,
      name: options.deviceName,
-     description : options.deviceDescription
+     description : options.deviceDescription,
+     user: options.user
    };
 
    debug(params);


### PR DESCRIPTION
Include the user id for validation on the API of devices with the same name 
