### PR TITLE
Change the way the device token and secret errors are reported

### DIFF
--- a/adsdk.js
+++ b/adsdk.js
@@ -210,8 +210,11 @@ function getDeviceToken(options, cb) {
   //make finished urls available
   makeUrls( options.apiServer );
 
-  Device.authenticate(options.deviceId, options.deviceSecret, function(err, res) {
-    if (err) return cb(new Error('Device Token Retrieval Error: '+err))
+  Device.authenticate(options.deviceId, options.deviceSecret, function (err, res) {
+    if (err) {
+      err.message = 'Device Token Retrieval Error';
+    }
+    return cb(err);
     debug('Device.getToken>', res.results.deviceToken);
     // v2 ? : v1
     var token = ( res.results.hasOwnProperty('deviceToken') ) ? res.results.deviceToken : res.results.device_token;
@@ -250,8 +253,11 @@ function authenticate(options, cb) {
     },
     function(cb) {
       if (has(options, 'deviceName')) {
-        Device.register(options.deviceId, function(err, results){
-          if (err) cb(new Error('Device Secret Retrieval Error:'+err))
+        Device.register(options.deviceId, function (err, results) {
+          if (err) {
+            err.message = 'Device Secret Retrieval Error';
+          }
+          return cb(err);
           admatrix.state.device.secret = results.results.device_token;
           cb();
         });
@@ -260,8 +266,11 @@ function authenticate(options, cb) {
       }
     },
     function getDeviceToken(cb){
-      Device.authenticate( options.deviceId, admatrix.state.device.secret, function(err, results){
-        if (err) return cb(new Error('Device Token Retrieval Error: '+err))
+      Device.authenticate(options.deviceId, admatrix.state.device.secret, function (err, results) {
+        if (err) {
+          err.message = 'Device Token Retrieval Error';
+        }
+        return cb(err);
         admatrix.state.device.token = results.results.device_token;
         cb();
       })

--- a/services/Device.js
+++ b/services/Device.js
@@ -139,7 +139,9 @@ function authenticateDevice(deviceId, deviceSecret, cb) {
     url: url,
     form: postOpts,
     json: true
-  }).then(function(results){ cb(null, results); }, handleError);
+  }).then(function (results) { cb(null, results); }, function (err) {
+    handleError(err, cb);
+  });
 }
 
 function registerDevice(deviceId, cb) {
@@ -155,12 +157,13 @@ function registerDevice(deviceId, cb) {
   }).fail(cb);
 }
 
-function handleError(err) {
+function handleError(err, cb) {
   try {
     var err = JSON.parse(err);
   } catch (e) {
-    console.error('Device Error', err);
+    debug('Device Error', err);
   } finally {
     console.error('API Error: ', err.status_code, '-', err.error);
+    if (!_.isUndefined(cb)) cb(err);
   }
 }


### PR DESCRIPTION
This is required to properly identify the issue when MOS fails to initialize